### PR TITLE
Fixed Issue Replaced 'completes' with 'acknowledges' in Contributions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,7 +11,7 @@ Contributors retain the copyright to their intellectual property.
 
 #### Contributions ####
 
-All contributions to FarmData2 will be licensed as a [Free Cultural Work] using the applicable license agreements as described below. Thus, before any contribution will be accepted __the contributor must certify that they have the right to license the contributed intellectual property__ under the applicable license agreement. This is done explicitly when when a contributor completes the [Developer Certificate of Origin] when opening a Pull Request, or implicitly when posting content to any public forums of the project (for example, but not limited to, issue trackers, message boards or discussion areas).
+All contributions to FarmData2 will be licensed as a [Free Cultural Work] using the applicable license agreements as described below. Thus, before any contribution will be accepted __the contributor must certify that they have the right to license the contributed intellectual property__ under the applicable license agreement. This is done explicitly when when a contributor acknowledge the [Developer Certificate of Origin] when opening a Pull Request, or implicitly when posting content to any public forums of the project (for example, but not limited to, issue trackers, message boards or discussion areas).
 
 [Developer Certificate of Origin]: https://developercertificate.org/
 


### PR DESCRIPTION
Replace 'completes' with 'acknowledges' in Contributions

__Pull Request Description__

Replace 'completes' with 'acknowledges' in Contributions
Fixes #22 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
